### PR TITLE
Feature/refactor page store

### DIFF
--- a/src/features/editor/components/Canvas/PageCanvas/PageCanvas.tsx
+++ b/src/features/editor/components/Canvas/PageCanvas/PageCanvas.tsx
@@ -2,13 +2,13 @@ import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { Box } from 'grommet'
 
 import { SELECTOR_PREFIX } from '@src/features/editor/constants/DnD'
-import { usePageStore } from '@src/features/editor/store/usePageStore'
+import { useSectionStore } from '@features/editor/store/section/useSectionStore'
 import type { PageCanvasProps } from './PageCanvas.types'
 import { DroppableCanvas } from '../DroppableCanvas'
 import { PageSectionRenderer } from '../PageSectionRenderer'
 
 const PageCanvas = ({ overSectionId, activeId }: PageCanvasProps) => {
-  const sections = usePageStore((state) => state.sections)
+  const sections = useSectionStore((state) => state.sections)
 
   const sectionIds = sections.map((s) => s.id)
   const isDraggingFromSelector =

--- a/src/features/editor/components/Canvas/SortableSection/SortableSection.tsx
+++ b/src/features/editor/components/Canvas/SortableSection/SortableSection.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
-import { usePageStore } from '@src/features/editor/store/usePageStore'
 import {
   DRAGGING_Z_INDEX,
   NORMAL_Z_INDEX,
@@ -8,10 +7,11 @@ import {
   DRAGGING_OPACITY,
   NORMAL_DRAGGING_OPACITY,
 } from '@src/features/editor/constants/DnD'
-import type { PageStore } from '@src/features/editor/types'
 import type { SortableSectionProps } from './SortableSection.types'
+import { useSectionStore } from '@features/editor/store/section/useSectionStore'
+import type { SectionStore } from '@features/editor/store/section/section.type'
 
-const selectSectionSelector = (state: PageStore) => state.selectSection
+const selectSectionSelector = (state: SectionStore) => state.selectSection
 
 const SortableSection: React.FC<SortableSectionProps> = ({ id, children }) => {
   const {
@@ -28,7 +28,7 @@ const SortableSection: React.FC<SortableSectionProps> = ({ id, children }) => {
     },
   })
 
-  const selectSection = usePageStore(selectSectionSelector)
+  const selectSection = useSectionStore(selectSectionSelector)
 
   useEffect(() => {
     if (isDragging) {

--- a/src/features/editor/components/Overlay/Inspectable/Inspectable.tsx
+++ b/src/features/editor/components/Overlay/Inspectable/Inspectable.tsx
@@ -2,9 +2,9 @@ import React, { useState } from 'react'
 
 import { Box } from 'grommet'
 import { getComponentLabel } from '@src/features/editor/utils/getComponentLabel'
-import { usePageStore } from '@src/features/editor/store/usePageStore'
 import type { InspectableProps } from './Inspectable.types'
 import { InspectorOverlay } from '../InspectorOverlay'
+import { useSectionStore } from '@features/editor/store/section/useSectionStore'
 
 const Inspectable: React.FC<InspectableProps> = ({
   id,
@@ -13,8 +13,8 @@ const Inspectable: React.FC<InspectableProps> = ({
   overlayLabelPosition = 'above',
   showInspectorOverlay = true,
 }) => {
-  const selectedId = usePageStore((s) => s.selectedId)
-  const selectSection = usePageStore((s) => s.selectSection)
+  const selectedId = useSectionStore((s) => s.selectedId)
+  const selectSection = useSectionStore((s) => s.selectSection)
 
   const [hovered, setHovered] = useState(false)
 

--- a/src/features/editor/components/Panels/PanelPageEditor/PanelPageEditor.tsx
+++ b/src/features/editor/components/Panels/PanelPageEditor/PanelPageEditor.tsx
@@ -1,7 +1,7 @@
 import { Box, FormField, Heading, Text, TextInput } from 'grommet'
 
 import { Eclipse, Layers, Pencil, Settings } from 'lucide-react'
-import { usePageStore } from '@src/features/editor/store/usePageStore'
+import { useSectionStore } from '@features/editor/store/section/useSectionStore'
 import {
   PanelBox,
   PanelBoxCollapsible,
@@ -14,11 +14,11 @@ import {
 } from '@components/cms/ui'
 
 const PanelPageEditor = () => {
-  const selectedId = usePageStore((s) => s.selectedId)
-  const section = usePageStore((s) =>
+  const selectedId = useSectionStore((s) => s.selectedId)
+  const section = useSectionStore((s) =>
     s.sections.find((sec) => sec.id === selectedId)
   )
-  const updateProps = usePageStore((s) => s.updateSectionProps)
+  const updateProps = useSectionStore((s) => s.updateSectionProps)
 
   if (!section)
     return (

--- a/src/features/editor/hooks/usePageDnD.ts
+++ b/src/features/editor/hooks/usePageDnD.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 import type { Active, DragStartEvent, DragOverEvent } from '@dnd-kit/core'
-import { usePageStore } from '@src/features/editor/store/usePageStore'
+import { useSectionStore } from '../store/section/useSectionStore'
 import { arrayMove } from '@dnd-kit/sortable'
 import { insertSectionAtUtil } from '@src/features/editor/utils/insertSectionAt'
 import {
@@ -12,8 +12,8 @@ import {
 import { SELECTOR_PREFIX } from '@src/features/editor/constants/DnD'
 
 export function usePageDnD() {
-  const sections = usePageStore((state) => state.sections)
-  const setSections = usePageStore((state) => state.setSections)
+  const sections = useSectionStore((state) => state.sections)
+  const setSections = useSectionStore((state) => state.setSections)
 
   const [overSectionId, setOverSectionId] = useState<string | null>(null)
   const [activeId, setActiveId] = useState<string | null>(null)

--- a/src/features/editor/mocks/mockSections.ts
+++ b/src/features/editor/mocks/mockSections.ts
@@ -1,6 +1,6 @@
 import type { Section } from '../schemas/section.schema'
 
-const sectionsMock: Section[] = [
+const mockSections: Section[] = [
   {
     id: 'canvas-nav',
     name: 'Nav',
@@ -110,4 +110,4 @@ const sectionsMock: Section[] = [
   },
 ]
 
-export default sectionsMock
+export default mockSections

--- a/src/features/editor/services/createSectionFromRegistry.ts
+++ b/src/features/editor/services/createSectionFromRegistry.ts
@@ -1,0 +1,24 @@
+import { v4 as uuidv4 } from 'uuid'
+import { componentsRegistry } from '@src/registry/componentRegistry'
+import { getComponentMeta } from '../utils/getComponentMeta'
+import { extractDefaultProps } from '../utils/extractDefaultProps'
+import { SectionSchema } from '../schemas/section.schema'
+
+export const createSectionFromRegistry = async (name: string) => {
+  const loader = componentsRegistry[name as keyof typeof componentsRegistry]
+  if (!loader) return
+  const metaModule = await loader()
+  const meta = getComponentMeta(metaModule)
+  const props = extractDefaultProps(meta.data?.props)
+  const newSection = {
+    id: uuidv4(),
+    name,
+    props,
+  }
+  const result = SectionSchema.safeParse(newSection)
+  if (!result.success) {
+    console.warn('Section validation failed:', result.error)
+    return
+  }
+  return result.data
+}

--- a/src/features/editor/store/section/section.actions.ts
+++ b/src/features/editor/store/section/section.actions.ts
@@ -40,7 +40,7 @@ export const addSection =
   async (name: string) => {
     const newSection = await createSectionFromRegistry(name)
     if (!newSection) {
-      console.warn(`No se pudo crear la sección '${name}'`)
+      console.warn(`The section '${name}' could not be created`)
       return
     }
     set((state) => ({

--- a/src/features/editor/store/section/section.actions.ts
+++ b/src/features/editor/store/section/section.actions.ts
@@ -1,0 +1,49 @@
+import type { Section } from '@features/editor/schemas/section.schema'
+import type { SectionStore } from './section.type'
+import { SectionSchema } from '@features/editor/schemas/section.schema'
+import { createSectionFromRegistry } from '@features/editor/services/createSectionFromRegistry'
+
+export const setSections =
+  (set: (fn: (state: SectionStore) => Partial<SectionStore>) => void) =>
+  (sections: Section[]) =>
+    set(() => ({ sections }))
+
+export const selectSection =
+  (set: (fn: (state: SectionStore) => Partial<SectionStore>) => void) =>
+  (id: string | null) =>
+    set(() => ({ selectedId: id }))
+
+export const updateSectionProps =
+  (set: (fn: (state: SectionStore) => Partial<SectionStore>) => void) =>
+  (id: string, newProps: Record<string, unknown>) => {
+    set((state) => {
+      const updatedSections = state.sections.map((section) => {
+        if (section.id !== id) return section
+        const updatedProps = { ...section.props, ...newProps }
+        const updatedSection = { ...section, props: updatedProps }
+        const validationResult = SectionSchema.safeParse(updatedSection)
+        if (!validationResult.success) {
+          console.warn(
+            `Failed to update section props for id=${id}:`,
+            validationResult.error
+          )
+          return section
+        }
+        return updatedSection
+      })
+      return { sections: updatedSections }
+    })
+  }
+
+export const addSection =
+  (set: (fn: (state: SectionStore) => Partial<SectionStore>) => void) =>
+  async (name: string) => {
+    const newSection = await createSectionFromRegistry(name)
+    if (!newSection) {
+      console.warn(`No se pudo crear la sección '${name}'`)
+      return
+    }
+    set((state) => ({
+      sections: [...state.sections, newSection],
+    }))
+  }

--- a/src/features/editor/store/section/section.selectors.ts
+++ b/src/features/editor/store/section/section.selectors.ts
@@ -1,0 +1,10 @@
+import type { Section } from '@features/editor/schemas/section.schema'
+import type { SectionStore } from './section.type'
+
+export const getSections = (state: SectionStore): Section[] => state.sections
+
+export const getSelectedSection = (
+  state: SectionStore
+): Section | undefined => {
+  return state.sections.find((section) => section.id === state.selectedId)
+}

--- a/src/features/editor/store/section/section.type.ts
+++ b/src/features/editor/store/section/section.type.ts
@@ -1,0 +1,10 @@
+import type { Section } from '@features/editor/schemas/section.schema'
+
+export type SectionStore = {
+  sections: Section[]
+  selectedId: string | null
+  setSections: (sections: Section[]) => void
+  updateSectionProps: (id: string, newProps: Record<string, unknown>) => void
+  selectSection: (id: string | null) => void
+  addSection: (name: string) => void
+}

--- a/src/features/editor/store/section/useSectionStore.ts
+++ b/src/features/editor/store/section/useSectionStore.ts
@@ -20,7 +20,7 @@ export const useSectionStore = create(
       addSection: addSection(set),
     }),
     {
-      name: 'page-store',
+      name: 'section-store',
     }
   )
 )

--- a/src/features/editor/store/section/useSectionStore.ts
+++ b/src/features/editor/store/section/useSectionStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import mockSections from '@features/editor/mocks/mockSections'
+import {
+  setSections,
+  selectSection,
+  updateSectionProps,
+  addSection,
+} from './section.actions'
+import type { SectionStore } from './section.type'
+
+export const useSectionStore = create(
+  persist<SectionStore>(
+    (set) => ({
+      sections: mockSections,
+      selectedId: null,
+      setSections: setSections(set),
+      selectSection: selectSection(set),
+      updateSectionProps: updateSectionProps(set),
+      addSection: addSection(set),
+    }),
+    {
+      name: 'page-store',
+    }
+  )
+)

--- a/src/features/editor/store/usePageStore.ts
+++ b/src/features/editor/store/usePageStore.ts
@@ -5,10 +5,10 @@ import { componentsRegistry } from '@registry/componentRegistry'
 import { extractDefaultProps } from '@src/features/editor/utils/extractDefaultProps'
 import { SectionSchema } from '../schemas/section.schema'
 import { getComponentMeta } from '../utils/getComponentMeta'
-import sectionsMock from '../mocks/sections'
+import mockSections from '../mocks/mockSections'
 
 export const usePageStore = create<PageStore>((set) => ({
-  sections: sectionsMock,
+  sections: mockSections,
   selectedId: null,
   setSections: (sections) => set({ sections }),
   selectSection: (id) => set({ selectedId: id }),

--- a/src/features/editor/types/index.ts
+++ b/src/features/editor/types/index.ts
@@ -6,5 +6,9 @@ export type PageStore = {
   setSections: (sections: Section[]) => void
   updateSectionProps: (id: string, newProps: Record<string, unknown>) => void
   selectSection: (id: string | null) => void
-  addSection: (type: string, props?: Record<string, unknown>) => void
+  addSection: (
+    id: string,
+    name: string,
+    props?: Record<string, unknown>
+  ) => void
 }

--- a/src/features/editor/utils/insertSectionAt.ts
+++ b/src/features/editor/utils/insertSectionAt.ts
@@ -1,8 +1,9 @@
 import { componentsRegistry } from '@registry/componentRegistry'
 import { v4 as uuidv4 } from 'uuid'
-import type { Section } from '@features/editor/types'
+
 import type { ComponentMeta } from '@components/site/types'
 import { extractDefaultProps } from '@src/features/editor/utils/extractDefaultProps'
+import type { Section } from '../schemas/section.schema'
 
 export async function insertSectionAtUtil(
   sections: Section[],


### PR DESCRIPTION
This pull request refactors the state management for sections in the editor by introducing a dedicated `useSectionStore` and moving related logic out of `usePageStore`. It also adds new utilities for creating and managing sections. The most important changes are grouped below:

### Refactoring State Management:
* Replaced `usePageStore` with `useSectionStore` across multiple components for handling section-related state, such as `PageCanvas`, `SortableSection`, `Inspectable`, and `PanelPageEditor` (`[[1]](diffhunk://#diff-a0ba956636401b25749d03b4006ba69aa22a8e9d9ab34481d3f1945ef2280176L5-R11)`, `[[2]](diffhunk://#diff-a68a397c79e50b99725c30b891b173ad40f73cfe9b305e1ce94020f47f736d49L3-R14)`, `[[3]](diffhunk://#diff-a68a397c79e50b99725c30b891b173ad40f73cfe9b305e1ce94020f47f736d49L31-R31)`, `[[4]](diffhunk://#diff-dfd254459b3cccc937c3d0e6f8526c419d8407a38cbbf49bd7825c09233b280bL5-R7)`, `[[5]](diffhunk://#diff-dfd254459b3cccc937c3d0e6f8526c419d8407a38cbbf49bd7825c09233b280bL16-R17)`, `[[6]](diffhunk://#diff-0cfbb3e3068fbecccb836e9c71424f4736536faf5bebf17dafff8b8368794c47L4-R4)`, `[[7]](diffhunk://#diff-0cfbb3e3068fbecccb836e9c71424f4736536faf5bebf17dafff8b8368794c47L17-R21)`, `[[8]](diffhunk://#diff-3083c4c93628a52fd7ab9628d9bcb443fba824a4851974d76ba4fa906d7a10d5L3-R3)`, `[[9]](diffhunk://#diff-3083c4c93628a52fd7ab9628d9bcb443fba824a4851974d76ba4fa906d7a10d5L15-R16)`).

### New Section Store:
* Introduced `useSectionStore` using Zustand, with persistence enabled, to manage sections and selected section state (`[src/features/editor/store/section/useSectionStore.tsR1-R26](diffhunk://#diff-397b8fc335cd063dceda37af7c3bdf387329e89df5dbff9eebdfff95557b7517R1-R26)`).
* Added `section.actions.ts` with actions for setting sections, selecting a section, updating section properties, and adding new sections (`[src/features/editor/store/section/section.actions.tsR1-R49](diffhunk://#diff-da0001d7cadc9b401edaac61703890fdbf8c05ce42a399424f58b89552ac888cR1-R49)`).
* Created selectors in `section.selectors.ts` for retrieving sections and the currently selected section (`[src/features/editor/store/section/section.selectors.tsR1-R10](diffhunk://#diff-2bf00e476ce370d67af5b7c599d7d5456f7347c08b6dcd005dc7d957f5736735R1-R10)`).
* Defined the `SectionStore` type in `section.type.ts` (`[src/features/editor/store/section/section.type.tsR1-R10](diffhunk://#diff-f9572ca1fd1d2b1932a3ecf9b309ed9b9896a2ff03d0e799db9e9b4b4a801e8fR1-R10)`).

### Utilities and Services:
* Added `createSectionFromRegistry` utility for creating a section from the component registry, including validation against the `SectionSchema` (`[src/features/editor/services/createSectionFromRegistry.tsR1-R24](diffhunk://#diff-b5b95fb2deb2d6624a2c22e68c9fda98cf776cc5bcdab570ae1e3e4994575bfdR1-R24)`).
* Updated `insertSectionAtUtil` to use the new `Section` type (`[src/features/editor/utils/insertSectionAt.tsL3-R6](diffhunk://#diff-957c3ef561c29745776ae0bb8f3607353b468afcc76725ce50cfcd656a1e74b6L3-R6)`).

### Updates to Mock Data:
* Renamed and updated the mock sections file from `sections.ts` to `mockSections.ts` for consistency with naming conventions (`[[1]](diffhunk://#diff-6bb526e6fddb9137f45e40b7db3c04f8d9c704b7f8a4363989443e852cdc9aeaL3-R3)`, `[[2]](diffhunk://#diff-6bb526e6fddb9137f45e40b7db3c04f8d9c704b7f8a4363989443e852cdc9aeaL113-R113)`).

### Deprecation of `usePageStore`:
* Removed section-related logic from `usePageStore` and updated its persistence configuration to focus on page-level state (`[src/features/editor/store/usePageStore.tsL2-R55](diffhunk://#diff-a14fa401ddd2be71bf984ff0ae2c44ec84564d71f11532b577e91d084246887eL2-R55)`).
* Updated the `PageStore` type to reflect the removal of section-related methods (`[src/features/editor/types/index.tsL9-R13](diffhunk://#diff-33d2fcfdf09f055d2371b3fe340350e5c704b5d22257f8ab8f48e4c364b6ec78L9-R13)`).