### PR TITLE
fix: Adjust editor and default layout

### DIFF
--- a/src/components/cms/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/components/cms/layouts/DefaultLayout/DefaultLayout.tsx
@@ -1,26 +1,30 @@
-import { Grid, Box } from '@chakra-ui/react'
+import { Grid, GridItem } from '@chakra-ui/react'
 import Header from '@src/features/editor/components/Header/Header'
 import type { DefaultLayoutProps } from './DefaultLayout.types'
 
 function DefaultLayout({ children }: DefaultLayoutProps) {
   return (
     <Grid
-      templateRows="auto 1fr auto"
+      templateAreas={`"header" "content"`}
+      templateRows="52px 1fr"
       templateColumns="1fr"
-      templateAreas="
-        'header'
-        'content'
-      "
-      height="100vh"
+      h="100vh"
+      w="100vw"
       overflow="hidden"
+      gap={0}
       data-testid="default-layout"
     >
-      <Box gridArea="header" data-testid="header">
+      <GridItem gridArea="header" data-testid="header">
         <Header />
-      </Box>
-      <Box gridArea="content" data-testid="content">
+      </GridItem>
+      <GridItem
+        gridArea="content"
+        data-testid="content"
+        h="100%"
+        overflow="auto"
+      >
         {children}
-      </Box>
+      </GridItem>
     </Grid>
   )
 }

--- a/src/components/cms/layouts/EditorLayout/EditorLayout.tsx
+++ b/src/components/cms/layouts/EditorLayout/EditorLayout.tsx
@@ -1,6 +1,6 @@
 import { DndContext, DragOverlay, closestCorners } from '@dnd-kit/core'
 import { usePageDnD } from '@src/features/editor/hooks/usePageDnD'
-import { Grid, Box } from '@chakra-ui/react'
+import { Grid, GridItem } from '@chakra-ui/react'
 
 import {
   ElementSelector,
@@ -31,21 +31,26 @@ function EditorLayout() {
     >
       <Grid
         templateRows="auto 1fr auto"
-        templateColumns="minmax(52px, 52px) minmax(270px, 270px) 1fr minmax(290px, 290px)"
+        templateColumns="auto 1fr minmax(290px, 290px)"
         templateAreas="
-          'left-sidebar left-panels center-preview right-editor'
+          'left-sidebar center-preview right-editor'
         "
-        height="100vh"
+        h="100%"
+        w="100%"
         overflow="hidden"
         data-testid="editor-layout"
       >
-        <Box gridArea="left-sidebar" data-testid="left-sidebar">
+        <GridItem
+          gridArea="left-sidebar"
+          data-testid="left-sidebar"
+          h="100%"
+          display="flex"
+          overflow="auto"
+        >
           <Sidebar />
-        </Box>
-        <Box gridArea="left-panels" data-testid="left-panels">
           <ElementSelector />
-        </Box>
-        <Box
+        </GridItem>
+        <GridItem
           gridArea="center-preview"
           background="#212121"
           alignItems="center"
@@ -54,10 +59,10 @@ function EditorLayout() {
           data-testid="center-preview"
         >
           <PageCanvas overSectionId={overSectionId} activeId={activeId} />
-        </Box>
-        <Box gridArea="right-editor" data-testid="right-editor">
+        </GridItem>
+        <GridItem gridArea="right-editor" data-testid="right-editor" h="100%">
           <PanelPageEditor />
-        </Box>
+        </GridItem>
       </Grid>
 
       <DragOverlay>

--- a/src/features/editor/components/Sidebar/ElementSelector/ElementSelector.tsx
+++ b/src/features/editor/components/Sidebar/ElementSelector/ElementSelector.tsx
@@ -33,7 +33,7 @@ const ElementSelector = () => {
   if (loading) return <PanelWrapper>Loading...</PanelWrapper>
 
   return (
-    <PanelWrapper borderSide="right">
+    <PanelWrapper borderSide="right" width={'290px'} fill={false}>
       <PanelBox>
         <Heading level={5} margin="none">
           UI Section Components

--- a/src/features/editor/components/Sidebar/Sidebar.tsx
+++ b/src/features/editor/components/Sidebar/Sidebar.tsx
@@ -28,7 +28,12 @@ const Sidebar = ({ links = LINKS_DATA }: SidebarProps) => {
   const settingsIndex = links.length
 
   return (
-    <PanelWrapper borderSide="right" justify="between">
+    <PanelWrapper
+      borderSide="right"
+      justify="between"
+      width="52px"
+      fill={false}
+    >
       <PanelBox borderSide={false} pad="none" flex={false}>
         <Nav gap="none">
           {links?.map(({ icon, label }, index) => (


### PR DESCRIPTION
This pull request refactors the layout components in the CMS editor to improve structure, consistency, and responsiveness. The key changes include replacing `Box` with `GridItem` for better alignment with the `Grid` layout, simplifying grid templates, and adding explicit width and overflow properties for improved layout control.

### Layout Component Refactor:

* **`DefaultLayout` Updates**:
  - Replaced `Box` with `GridItem` for `header` and `content` areas.
  - Simplified `templateAreas` and added `w="100vw"` and `gap={0}` for consistent layout behavior. (`src/components/cms/layouts/DefaultLayout/DefaultLayout.tsx`, [src/components/cms/layouts/DefaultLayout/DefaultLayout.tsxL1-R27](diffhunk://#diff-c8be21341e4b67182f3b356376d800f36b39903ff048d63b867012113c2ad46fL1-R27))

* **`EditorLayout` Updates**:
  - Replaced `Box` with `GridItem` for all grid areas (`left-sidebar`, `center-preview`, `right-editor`).
  - Removed the `left-panels` grid area and adjusted `templateColumns` accordingly.
  - Added `h="100%"`, `w="100%"`, and `overflow="auto"` for better responsiveness. (`src/components/cms/layouts/EditorLayout/EditorLayout.tsx`, [[1]](diffhunk://#diff-4e168e6163971e44c036145ab8ebea6d3219782f3ccb9d0bb3808a7941545553L3-R3) [[2]](diffhunk://#diff-4e168e6163971e44c036145ab8ebea6d3219782f3ccb9d0bb3808a7941545553L34-R53) [[3]](diffhunk://#diff-4e168e6163971e44c036145ab8ebea6d3219782f3ccb9d0bb3808a7941545553L57-R65)

### Sidebar and Panel Adjustments:

* **`ElementSelector`**:
  - Updated `PanelWrapper` to include a fixed width of `290px` and set `fill={false}` for more precise sizing. (`src/features/editor/components/Sidebar/ElementSelector/ElementSelector.tsx`, [src/features/editor/components/Sidebar/ElementSelector/ElementSelector.tsxL36-R36](diffhunk://#diff-e7a0cebcf2911e2263be5705290b8209e7d5b6739fb25dd515fabaf3db1a1922L36-R36))

* **`Sidebar`**:
  - Added a fixed width of `52px` to `PanelWrapper` and set `fill={false}` to ensure consistent sidebar dimensions. (`src/features/editor/components/Sidebar/Sidebar.tsx`, [src/features/editor/components/Sidebar/Sidebar.tsxL31-R36](diffhunk://#diff-7139dd538b1049126341470b0a7b97832ab8f193d5262ca3a6400474c6e87db6L31-R36))